### PR TITLE
Set release_only_on_main to false in CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,3 +17,4 @@ jobs:
       PLATFORMIO_AUTH_TOKEN: ${{ secrets.PLATFORMIO_AUTH_TOKEN }}
     with:
       prerelease: ${{ github.ref != 'refs/heads/main' }}
+      release_only_on_main: false

--- a/platformio.ini
+++ b/platformio.ini
@@ -96,3 +96,4 @@ build_flags =
 	-Ilib/IROCK_212_V2_4
 	-D HW_VERSION_2_4
 	${extra.build_flags_external}
+

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/Arvernus/PlatformIOGithubActions/main/schemas/project.json",
   "name": "IROCK_212",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "iRock OS for Hardware 212",
   "authors": [
     {


### PR DESCRIPTION
Updated the CI workflow configuration to set 'release_only_on_main' to false, allowing releases on branches other than main.